### PR TITLE
allow running solc without a tty

### DIFF
--- a/bin/solc
+++ b/bin/solc
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --read-only -ti --rm -e SOLC_VERSION="$SOLC_VERSION" --mount type=bind,source="$(pwd)",target=/workdir trailofbits/solc-select:latest $@
+docker run --read-only -i $([ -t 0 ] && echo -t) --rm -e SOLC_VERSION="$SOLC_VERSION" --mount type=bind,source="$(pwd)",target=/workdir trailofbits/solc-select:latest $@


### PR DESCRIPTION
I usually run solc from a build script, rather than interactively. Sometimes
these build scripts have their stdin attached to my terminal's TTY, and
sometimes they do not. When they do not, solc-select fails with the message
"the input device is not a TTY". This behavior is easy to see for yourself:

    $ solc < /dev/null
    the input device is not a TTY

The reason for this failure is that the `solc` script uses the `-t` flag on
`docker run`. When this flag is set, `docker run` refuses to run if stdin is not
a TTY.

This commit fixes this issue by setting the `-t` flag conditionally. If stdin is
a TTY (checked with `[ -t 0]`), it sets the flag. Otherwise it does not. This
causes the script to continue working as it did before when stdin is a TTY, and
now also work when stdin is not a TTY:

    $ solc < /dev/null
    No input files given. If you wish to use the standard input please specify "-" explicitly.

(^ solc doesn't print its usage message by default when stdin is not a TTY)