### PR TITLE
Validate minimum and maximum versions

### DIFF
--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -94,14 +94,18 @@ def valid_version(version):
     list_json = urllib.request.urlopen(url).read()
     latest_release = json.loads(list_json)["latestRelease"]
 
-    earliest_release = {'macosx-amd64': '0.3.6', 'linux-amd64': '0.4.0'}
+    earliest_release = {"macosx-amd64": "0.3.6", "linux-amd64": "0.4.0"}
 
     if match is None:
         raise argparse.ArgumentTypeError(f"Invalid version '{version}'.")
     if StrictVersion(version) > StrictVersion(latest_release):
-        raise argparse.ArgumentTypeError(f"Invalid version '{latest_release}' is the latest available version")
+        raise argparse.ArgumentTypeError(
+            f"Invalid version '{latest_release}' is the latest available version"
+        )
     if StrictVersion(version) < StrictVersion(earliest_release[soliditylang_platform()]):
-        raise argparse.ArgumentTypeError(f"Invalid version - only solc versions above '{earliest_release[soliditylang_platform()]}' are available")
+        raise argparse.ArgumentTypeError(
+            f"Invalid version - only solc versions above '{earliest_release[soliditylang_platform()]}' are available"
+        )
 
     return version
 

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -90,8 +90,19 @@ def switch_global_version(version):
 def valid_version(version):
     match = re.search(r"^(\d+).(\d+).(\d+)$", version)
 
+    url = f"https://binaries.soliditylang.org/{soliditylang_platform()}/list.json"
+    list_json = urllib.request.urlopen(url).read()
+    latest_release = json.loads(list_json)["latestRelease"]
+
+    earliest_release = {'macosx-amd64': '0.3.6', 'linux-amd64': '0.4.0'}
+
     if match is None:
         raise argparse.ArgumentTypeError(f"Invalid version '{version}'.")
+    if StrictVersion(version) > StrictVersion(latest_release):
+        raise argparse.ArgumentTypeError(f"Invalid version '{latest_release}' is the latest available version")
+    if StrictVersion(version) < StrictVersion(earliest_release[soliditylang_platform()]):
+        raise argparse.ArgumentTypeError(f"Invalid version - only solc versions above '{earliest_release[soliditylang_platform()]}' are available")
+
     return version
 
 

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -94,7 +94,7 @@ def valid_version(version):
     list_json = urllib.request.urlopen(url).read()
     latest_release = json.loads(list_json)["latestRelease"]
 
-    earliest_release = {"macosx-amd64": "0.3.6", "linux-amd64": "0.4.0"}
+    earliest_release = {"macosx-amd64": "0.3.6", "linux-amd64": "0.4.0", "windows-amd64": "0.4.5"}
 
     if match is None:
         raise argparse.ArgumentTypeError(f"Invalid version '{version}'.")


### PR DESCRIPTION
**Linux**
```
vagrant@ubuntu2004:~/solc-select/foo/solc-select$ solc-select install 0.3.1
usage: solc-select install [-h] [INSTALL_VERSIONS [INSTALL_VERSIONS ...]]
solc-select install: error: argument INSTALL_VERSIONS: Invalid version - only solc versions above '0.4.0' are available
vagrant@ubuntu2004:~/solc-select/foo/solc-select$ solc-select install 0.9.4
usage: solc-select install [-h] [INSTALL_VERSIONS [INSTALL_VERSIONS ...]]
solc-select install: error: argument INSTALL_VERSIONS: Invalid version '0.8.4' is the latest available version
vagrant@ubuntu2004:~/solc-select/foo/solc-select$ solc-select use 0.9.4
usage: solc-select use [-h] USE_VERSION
solc-select use: error: argument USE_VERSION: Invalid version '0.8.4' is the latest available version
vagrant@ubuntu2004:~/solc-select/foo/solc-select$ solc-select use 0.3.1
usage: solc-select use [-h] USE_VERSION
solc-select use: error: argument USE_VERSION: Invalid version - only solc versions above '0.4.0' are available
vagrant@ubuntu2004:~/solc-select/foo/solc-select$
```

**Mac OS X**
```
$ solc-select install 0.3.2
usage: solc-select install [-h] [INSTALL_VERSIONS [INSTALL_VERSIONS ...]]
solc-select install: error: argument INSTALL_VERSIONS: Invalid version - only solc versions above '0.3.6' are available
$ solc-select install 0.
9.1
usage: solc-select install [-h] [INSTALL_VERSIONS [INSTALL_VERSIONS ...]]
solc-select install: error: argument INSTALL_VERSIONS: Invalid version '0.8.4' is the latest available version
$ solc-select use 0.3.2
usage: solc-select use [-h] USE_VERSION
solc-select use: error: argument USE_VERSION: Invalid version - only solc versions above '0.3.6' are available
$ solc-select use 0.9.1
usage: solc-select use [-h] USE_VERSION
solc-select use: error: argument USE_VERSION: Invalid version '0.8.4' is the latest available version
```

Closes #46 