### PR TITLE
Refactoring storage 

### DIFF
--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -79,7 +79,8 @@ def solc():
     if res:
         (version, _) = res
         halt_old_architecture(version)
-        path = f"{artifacts_dir}/solc-{version}/solc-{version}"
+        path = f"{artifacts_dir}/solc-{version}/solc"
+        print(path)
         os.execv(path, [path] + sys.argv[1:])
     else:
         sys.exit(1)

--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -72,7 +72,8 @@ def solc():
     res = current_version()
     if res:
         (version, _) = res
-        path = f"{artifacts_dir}/solc-{version}"
+        path = f"{artifacts_dir}/solc-{version}/solc-{version}"
+        print(path)
         os.execv(path, [path] + sys.argv[1:])
     else:
         sys.exit(1)

--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -79,8 +79,7 @@ def solc():
     if res:
         (version, _) = res
         halt_old_architecture(version)
-        path = f"{artifacts_dir}/solc-{version}/solc"
-        print(path)
+        path = f"{artifacts_dir}/solc-{version}/solc-{version}"
         os.execv(path, [path] + sys.argv[1:])
     else:
         sys.exit(1)

--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import sys
+import shutil
 from .solc_select import (
     valid_install_arg,
     valid_version,
@@ -10,6 +11,8 @@ from .solc_select import (
     current_version,
     installed_versions,
     artifacts_dir,
+    halt_old_architecture,
+    upgrade_architecture,
 )
 
 
@@ -17,6 +20,7 @@ def solc_select():
     INSTALL_VERSIONS = "INSTALL_VERSIONS"
     USE_VERSION = "USE_VERSION"
     SHOW_VERSIONS = "SHOW_VERSIONS"
+    UPDATE = "UPDATE"
 
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(
@@ -38,6 +42,8 @@ def solc_select():
     )
     parser_use = subparsers.add_parser("versions", help="prints out all installed solc versions")
     parser_use.add_argument(SHOW_VERSIONS, nargs="*", help=argparse.SUPPRESS)
+    parser_use = subparsers.add_parser("update", help="upgrades solc-select")
+    parser_use.add_argument(UPDATE, nargs="*", help=argparse.SUPPRESS)
 
     args = vars(parser.parse_args())
 
@@ -62,7 +68,8 @@ def solc_select():
                 print(f"{version} (current, set by {source})")
             else:
                 print(version)
-
+    elif args.get(UPDATE) is not None:
+        upgrade_architecture()
     else:
         parser.parse_args(["--help"])
         sys.exit(0)
@@ -72,8 +79,8 @@ def solc():
     res = current_version()
     if res:
         (version, _) = res
+        halt_old_architecture(version)
         path = f"{artifacts_dir}/solc-{version}/solc-{version}"
-        print(path)
         os.execv(path, [path] + sys.argv[1:])
     else:
         sys.exit(1)

--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import sys
-import shutil
 from .solc_select import (
     valid_install_arg,
     valid_version,

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+import shutil
 import re
 import sys
 import urllib.request
@@ -10,6 +11,30 @@ home_dir = os.path.expanduser("~")
 solc_select_dir = f"{home_dir}/.solc-select"
 artifacts_dir = f"{solc_select_dir}/artifacts"
 os.makedirs(artifacts_dir, exist_ok=True)
+
+
+def halt_old_architecture(version: str):
+    if os.path.isfile(f"{artifacts_dir}/solc-{version}") or not os.path.isdir(
+        f"{artifacts_dir}/solc-{version}/solc-{version}"
+    ):
+        print("solc-select is out of date. Please run `solc-select update`")
+        sys.exit(1)
+
+
+def upgrade_architecture():
+    currently_installed = installed_versions()
+    if len(currently_installed) > 0:
+        if os.path.isfile(f"{artifacts_dir}/solc-{currently_installed[0]}"):
+            shutil.rmtree(artifacts_dir)
+            os.makedirs(artifacts_dir, exist_ok=True)
+            install_artifacts(currently_installed)
+            print("solc-select is now up to date! 🎉")
+        else:
+            print("solc-select is already up to date")
+            sys.exit(1)
+    else:
+        print("Run `solc-select install --help` for more information")
+        sys.exit(1)
 
 
 def current_version():

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -78,11 +78,11 @@ def install_artifacts(versions):
         artifact_file = f"{artifacts_dir}/solc-{version}/"
         os.makedirs(artifact_file, exist_ok=True)
         print(f"Installing '{version}'...")
-        urllib.request.urlretrieve(url, f"{artifact_file}/solc-{version}")
+        urllib.request.urlretrieve(url, f"{artifact_file}/solc")
         # NOTE: we could verify checksum here because the list.json file
         # provides checksums for artifacts, however those are keccak256 hashes
         # which are not possible to compute without additional dependencies
-        os.chmod(f"{artifact_file}/solc-{version}", 0o775)
+        os.chmod(f"{artifact_file}/solc", 0o775)
         print(f"Version '{version}' installed.")
 
 

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -15,7 +15,7 @@ os.makedirs(artifacts_dir, exist_ok=True)
 
 def halt_old_architecture(version: str):
     if os.path.isfile(f"{artifacts_dir}/solc-{version}") or not os.path.isdir(
-        f"{artifacts_dir}/solc-{version}/solc-{version}"
+        f"{artifacts_dir}/solc-{version}/"
     ):
         print("solc-select is out of date. Please run `solc-select update`")
         sys.exit(1)

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -57,7 +57,7 @@ def install_artifacts(versions):
         # NOTE: we could verify checksum here because the list.json file
         # provides checksums for artifacts, however those are keccak256 hashes
         # which are not possible to compute without additional dependencies
-        os.chmod(artifact_file, 0o775)
+        os.chmod(f"{artifact_file}/solc-{version}", 0o775)
         print(f"Version '{version}' installed.")
 
 

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -78,11 +78,11 @@ def install_artifacts(versions):
         artifact_file = f"{artifacts_dir}/solc-{version}/"
         os.makedirs(artifact_file, exist_ok=True)
         print(f"Installing '{version}'...")
-        urllib.request.urlretrieve(url, f"{artifact_file}/solc")
+        urllib.request.urlretrieve(url, f"{artifact_file}/solc-{version}")
         # NOTE: we could verify checksum here because the list.json file
         # provides checksums for artifacts, however those are keccak256 hashes
         # which are not possible to compute without additional dependencies
-        os.chmod(f"{artifact_file}/solc", 0o775)
+        os.chmod(f"{artifact_file}/solc-{version}", 0o775)
         print(f"Version '{version}' installed.")
 
 

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -50,9 +50,10 @@ def install_artifacts(versions):
                 continue
 
         url = get_url(version, artifact)
-        artifact_file = f"{artifacts_dir}/solc-{version}"
+        artifact_file = f"{artifacts_dir}/solc-{version}/"
+        os.makedirs(artifact_file, exist_ok=True)
         print(f"Installing '{version}'...")
-        urllib.request.urlretrieve(url, artifact_file)
+        urllib.request.urlretrieve(url, f"{artifact_file}/solc-{version}")
         # NOTE: we could verify checksum here because the list.json file
         # provides checksums for artifacts, however those are keccak256 hashes
         # which are not possible to compute without additional dependencies


### PR DESCRIPTION
Implementation of PR currently blocking #54. This PR introduces breaking changes to the storage of solc binaries from a single folder, to individual folders with their respective binaries: 

```
├── solc-0.3.6
│   └── solc-0.3.6
├── solc-0.8.1
│   └── solc-0.8.1
└── solc-0.8.4
    └── solc-0.8.4
```