### PR TITLE
Add sha256 checksum to `solc-select install` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 __pycache__
 artifacts/
 global-version
+
+.idea
+build/
+dist/

--- a/scripts/test_solc_upgrade.sh
+++ b/scripts/test_solc_upgrade.sh
@@ -4,7 +4,7 @@
 sudo pip3 uninstall solc-select
 sudo pip3 install solc-select
 old_solc_version=$(solc --version)
-solc-select install 0.4.6 0.5.0 0.6.12 0.7.3 0.8.3
+solc-select install 0.4.11 0.5.0 0.6.12 0.7.3 0.8.3
 all_old_versions=$(solc-select versions)
 
 ### Install new version of solc

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -113,7 +113,8 @@ def verify_checksum(version: str) -> None:
         sha256_factory = hashlib.sha256()
         keccak_factory = hashlib.sha3_256()
 
-        while chunk := f.read(1024000):  # ~1MB chunk
+        # 1024000(~1MB chunk)
+        for chunk in iter(lambda: f.read(1024000), b''):
             sha256_factory.update(chunk)
             keccak_factory.update(chunk)
 

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -1,4 +1,5 @@
 import argparse
+import hashlib
 import json
 from pathlib import Path
 from zipfile import ZipFile
@@ -76,6 +77,7 @@ def install_artifacts(versions: [str]) -> None:
         Path.mkdir(artifact_file_dir, parents=True, exist_ok=True)
         print(f"Installing '{version}'...")
         urllib.request.urlretrieve(url, artifact_file_dir.joinpath(f"solc-{version}"))
+        verify_checksum(version)
         # NOTE: we could verify checksum here because the list.json file
         # provides checksums for artifacts, however those are keccak256 hashes
         # which are not possible to compute without additional dependencies
@@ -102,6 +104,24 @@ def is_older_windows(version: str) -> bool:
     return soliditylang_platform() == "windows-amd64" and StrictVersion(version) <= StrictVersion(
         "0.7.1"
     )
+
+
+def verify_checksum(version):
+    list_json = urllib.request.urlopen(f"https://binaries.soliditylang.org/{soliditylang_platform()}/list.json").read()
+    builds = json.loads(list_json)["builds"]
+    matches = list(filter(lambda b: b["version"] == version, builds))
+    if not matches or not matches[0]['sha256']:
+        raise argparse.ArgumentTypeError(f"Error: Unable to retrieve checksum for {soliditylang_platform()} - {version}" )
+
+    soliditylang_hash = matches[0]['sha256']
+
+    ## calculate sha256 of local file
+    with open(artifacts_dir.joinpath(f"solc-{version}", f"solc-{version}"), "rb") as f:
+        file = f.read()  # read entire file as bytes
+        local_file_hash = f"0x{hashlib.sha256(file).hexdigest()}"
+
+    if soliditylang_hash != local_file_hash:
+        raise argparse.ArgumentTypeError(f"Error: Checksum mismatch {soliditylang_platform()} - {version}")
 
 
 def get_url(version: str, artifact: str) -> str:

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -107,13 +107,17 @@ def is_older_windows(version: str) -> bool:
 
 
 def verify_checksum(version):
-    list_json = urllib.request.urlopen(f"https://binaries.soliditylang.org/{soliditylang_platform()}/list.json").read()
+    list_json = urllib.request.urlopen(
+        f"https://binaries.soliditylang.org/{soliditylang_platform()}/list.json"
+    ).read()
     builds = json.loads(list_json)["builds"]
     matches = list(filter(lambda b: b["version"] == version, builds))
-    if not matches or not matches[0]['sha256']:
-        raise argparse.ArgumentTypeError(f"Error: Unable to retrieve checksum for {soliditylang_platform()} - {version}" )
+    if not matches or not matches[0]["sha256"]:
+        raise argparse.ArgumentTypeError(
+            f"Error: Unable to retrieve checksum for {soliditylang_platform()} - {version}"
+        )
 
-    soliditylang_hash = matches[0]['sha256']
+    soliditylang_hash = matches[0]["sha256"]
 
     ## calculate sha256 of local file
     with open(artifacts_dir.joinpath(f"solc-{version}", f"solc-{version}"), "rb") as f:
@@ -121,7 +125,9 @@ def verify_checksum(version):
         local_file_hash = f"0x{hashlib.sha256(file).hexdigest()}"
 
     if soliditylang_hash != local_file_hash:
-        raise argparse.ArgumentTypeError(f"Error: Checksum mismatch {soliditylang_platform()} - {version}")
+        raise argparse.ArgumentTypeError(
+            f"Error: Checksum mismatch {soliditylang_platform()} - {version}"
+        )
 
 
 def get_url(version: str, artifact: str) -> str:

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -77,10 +77,8 @@ def install_artifacts(versions: [str]) -> None:
         Path.mkdir(artifact_file_dir, parents=True, exist_ok=True)
         print(f"Installing '{version}'...")
         urllib.request.urlretrieve(url, artifact_file_dir.joinpath(f"solc-{version}"))
-        verify_checksum(version)
-        # NOTE: we could verify checksum here because the list.json file
-        # provides checksums for artifacts, however those are keccak256 hashes
-        # which are not possible to compute without additional dependencies
+        if not is_older_linux(version):  ## no checksum support for older linux yet
+            verify_checksum(version)
         if is_older_windows(version):
             with ZipFile(artifact_file_dir.joinpath(f"solc-{version}"), "r") as zip_ref:
                 zip_ref.extractall(path=artifact_file_dir)


### PR DESCRIPTION
After downloading the solc binary, this code uses python to calculate the `sha256` of the local binary, and compares the hash to the one provided by soliditylang. 🥳 If there is a mismatch, the code throws an error.

TODO: 
- [x] Merge #54, and rebase
- [x] Add tests for all versions pulled from soliditylang
- [x] Add checksums for the ones hosted in https://github.com/crytic/solc/blob/list-json/linux/amd64/list.json
- [x] Add tests for the ones hosted in https://github.com/crytic/solc

Closes #44 