### PR TITLE
More specific regex in `valid_version()`

### DIFF
--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -88,7 +88,7 @@ def switch_global_version(version):
 
 
 def valid_version(version):
-    match = re.search(r"^(\d+).(\d+).(\d+)$", version)
+    match = re.search(r"^(\d+)\.(\d+)\.(\d+)$", version)
 
     if match is None:
         raise argparse.ArgumentTypeError(f"Invalid version '{version}'.")


### PR DESCRIPTION
Currently, the regex to check for a valid solidity version is `^(\d+).(\d+).(\d+)$`. This PR changes the `.` to `\.` to be inline with expected solidity version format. Thanks!