### PR TITLE
Adds `--always-install` flag to `solc-select use`

### DIFF
--- a/scripts/test_solc.sh
+++ b/scripts/test_solc.sh
@@ -92,3 +92,24 @@ if [[ "$execute" != *"Error: Explicit type conversion not allowed"* ]]; then
   exit 255
 fi
 echo "SUCCESS: solc080_fail_compile"
+
+UNINSTALL_PATH=$HOME/.solc-select/artifacts/solc-0.8.9
+rm -rf $UNINSTALL_PATH # uninstall solc 0.8.9
+execute=$(echo "y" | solc-select use 0.8.9)
+if [[ "$execute" != *"Switched global version to 0.8.9"* ]]; then
+  echo "FAILED: install yes install prompt"
+  exit 255
+fi
+echo "SUCCESS: install yes install prompt"
+
+UNINSTALL_PATH=$HOME/.solc-select/artifacts/solc-0.8.1
+rm -rf $UNINSTALL_PATH # uninstall solc 0.8.1
+execute=$(echo "n" | solc-select use 0.8.1)
+echo $execute
+if [[ $execute != *"Would you like to install?"* ]]; then
+  echo "FAILED: install no install prompt"
+  exit 255
+fi
+echo "SUCCESS: install no install prompt"
+
+solc-select install 0.8.1 &> /dev/null

--- a/scripts/test_solc.sh
+++ b/scripts/test_solc.sh
@@ -95,21 +95,20 @@ echo "SUCCESS: solc080_fail_compile"
 
 UNINSTALL_PATH=$HOME/.solc-select/artifacts/solc-0.8.9
 rm -rf $UNINSTALL_PATH # uninstall solc 0.8.9
-execute=$(echo "y" | solc-select use 0.8.9)
+execute=$(solc-select use 0.8.9 --always-install)
 if [[ "$execute" != *"Switched global version to 0.8.9"* ]]; then
-  echo "FAILED: install yes install prompt"
+  echo "FAILED: use - always install"
   exit 255
 fi
-echo "SUCCESS: install yes install prompt"
+echo "SUCCESS:  use - always install"
 
 UNINSTALL_PATH=$HOME/.solc-select/artifacts/solc-0.8.1
 rm -rf $UNINSTALL_PATH # uninstall solc 0.8.1
-execute=$(echo "n" | solc-select use 0.8.1)
-echo $execute
-if [[ $execute != *"Would you like to install?"* ]]; then
-  echo "FAILED: install no install prompt"
+execute=$(solc-select use 0.8.1 2>&1)
+if [[ $execute != *"'0.8.1' must be installed prior to use"* ]]; then
+  echo "FAILED: use - no install"
   exit 255
 fi
-echo "SUCCESS: install no install prompt"
+echo "SUCCESS: use - no install"
 
 solc-select install 0.8.1 &> /dev/null

--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -37,8 +37,9 @@ def solc_select() -> None:
     )
     parser_use = subparsers.add_parser("use", help="change the version of global solc compiler")
     parser_use.add_argument(
-        USE_VERSION, help="solc version you want to use (eg: 0.4.25)", type=valid_version
+        USE_VERSION, help="solc version you want to use (eg: 0.4.25)", type=valid_version, nargs="?"
     )
+    parser_use.add_argument("--always-install", action="store_true")
     parser_use = subparsers.add_parser("versions", help="prints out all installed solc versions")
     parser_use.add_argument(SHOW_VERSIONS, nargs="*", help=argparse.SUPPRESS)
     parser_use = subparsers.add_parser("update", help="upgrades solc-select")
@@ -56,7 +57,7 @@ def solc_select() -> None:
             install_artifacts(args.get(INSTALL_VERSIONS))
 
     elif args.get(USE_VERSION) is not None:
-        switch_global_version(args.get(USE_VERSION))
+        switch_global_version(args.get(USE_VERSION), args.get("always_install"))
 
     elif args.get(SHOW_VERSIONS) is not None:
         res = current_version()

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -53,7 +53,6 @@ def current_version() -> (str, str):
             raise argparse.ArgumentTypeError(
                 "No solc version set. Run `solc-select use VERSION` or set SOLC_VERSION environment variable."
             )
-            return None
     return (version, source)
 
 
@@ -116,9 +115,12 @@ def switch_global_version(version: str) -> None:
             f.write(version)
         print("Switched global version to", version)
     elif version in get_available_versions():
-        raise argparse.ArgumentTypeError(
-            f"You need to install '{version}' prior to using it. Use `solc-select install {version}`"
+        want_to = input(
+            f"'{version}' must be installed prior to use. Would you like to install? [y/n] "
         )
+        if want_to.lower() == "y":
+            install_artifacts(version)
+            switch_global_version(version)
     else:
         raise argparse.ArgumentTypeError(f"Unknown version '{version}'")
 

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -109,18 +109,17 @@ def get_url(version: str, artifact: str) -> str:
     return f"https://binaries.soliditylang.org/{soliditylang_platform()}/{artifact}"
 
 
-def switch_global_version(version: str) -> None:
+def switch_global_version(version: str, always_install: bool) -> None:
     if version in installed_versions():
         with open(f"{solc_select_dir}/global-version", "w") as f:
             f.write(version)
         print("Switched global version to", version)
     elif version in get_available_versions():
-        want_to = input(
-            f"'{version}' must be installed prior to use. Would you like to install? [y/n] "
-        )
-        if want_to.lower() == "y":
+        if always_install:
             install_artifacts(version)
-            switch_global_version(version)
+            switch_global_version(version, always_install)
+        else:
+            raise argparse.ArgumentTypeError(f"'{version}' must be installed prior to use.")
     else:
         raise argparse.ArgumentTypeError(f"Unknown version '{version}'")
 


### PR DESCRIPTION
```
$ solc-select use 0.8.9
'0.8.9' must be installed prior to use. Would you like to install? [y/n] n

$ solc-select use 0.8.9
'0.8.9' must be installed prior to use. Would you like to install? [y/n] y
Installing '0.8.9'...
Version '0.8.9' installed.
Switched global version to 0.8.9
```