### PR TITLE
add support for use within virtualenv

### DIFF
--- a/solc_select/constants.py
+++ b/solc_select/constants.py
@@ -1,7 +1,11 @@
+import os
 from pathlib import Path
 
 # DIRs path
-HOME_DIR = Path.home()
+if "VIRTUAL_ENV" in os.environ:
+    HOME_DIR = Path(os.environ["VIRTUAL_ENV"])
+else:
+    HOME_DIR = Path.home()
 SOLC_SELECT_DIR = HOME_DIR.joinpath(".solc-select")
 ARTIFACTS_DIR = SOLC_SELECT_DIR.joinpath("artifacts")
 


### PR DESCRIPTION
When using within a virtual environment, solc-select attempts to access the binary from the user path and runs into a permission error. This pull request checks whether the user is invoking solc-select from within a virtualenv and changes the path accordingly.
Example error of current behavior:
```
File "/Users/<user>/.virtualenvs/test/lib/python3.9/site-packages/solc_select/__main__.py", line 77, in solc
    os.execv(path, [path] + sys.argv[1:])
PermissionError: [Errno 13] Permission denied
```