### PR TITLE
Fix multiple installations with `solc-select use` + `--always-install`

### DIFF
--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -158,7 +158,7 @@ def switch_global_version(version: str, always_install: bool) -> None:
         print("Switched global version to", version)
     elif version in get_available_versions():
         if always_install:
-            install_artifacts(version)
+            install_artifacts([version])
             switch_global_version(version, always_install)
         else:
             raise argparse.ArgumentTypeError(f"'{version}' must be installed prior to use.")


### PR DESCRIPTION
A single version string was passed to install_artifacts instead of a version
list. This caused install_artifacts to install other versions contained
in the requested version (e.g. 0.4.2 was installed as well when 0.4.25
was requested). Call the installation function with a list as intended,
so that the correct version and that version only is installed now.

Test case:
 * `rm ~/.solc-select -rf`
 * `solc-select use 0.4.25 --always-install`

Fixes: #95