### PR TITLE
deps: replace pysha3 with pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
             "solc = solc_select.__main__:solc",
         ]
     },
-    install_requires=["pysha3", "packaging"],
+    install_requires=["pycryptodome>=3.4.6", "packaging"],
 )

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -9,7 +9,7 @@ import sys
 import urllib.request
 from pathlib import Path
 from packaging.version import Version
-import sha3
+from Crypto.Hash import keccak
 from .constants import (
     LINUX_AMD64,
     MACOSX_AMD64,
@@ -113,7 +113,7 @@ def verify_checksum(version: str) -> None:
     # calculate sha256 and keccak256 checksum of the local file
     with open(ARTIFACTS_DIR.joinpath(f"solc-{version}", f"solc-{version}"), "rb") as f:
         sha256_factory = hashlib.sha256()
-        keccak_factory = sha3.keccak_256()
+        keccak_factory = keccak.new(digest_bits=256)
 
         # 1024000(~1MB chunk)
         for chunk in iter(lambda: f.read(1024000), b""):


### PR DESCRIPTION
pysha3 is unmaintained and does not compile in Python 3.11

Fixes: #126