### PR TITLE
Do not capture solc output

### DIFF
--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -83,13 +83,11 @@ def solc() -> None:
         path = ARTIFACTS_DIR.joinpath(f"solc-{version}", f"solc-{version}")
         halt_old_architecture(path)
         try:
-            # Display solc usage when invoked with help flag or without options
-            check_process = sys.argv[1:] not in ["--help", []]
-            process = subprocess.run(
-                [str(path)] + sys.argv[1:], stdout=subprocess.PIPE, stdin=None, check=check_process
+            subprocess.run(
+                [str(path)] + sys.argv[1:],
+                check=True,
             )
-            print(str(process.stdout, "utf-8"))
-        except subprocess.CalledProcessError:
-            sys.exit(1)
+        except subprocess.CalledProcessError as e:
+            sys.exit(e.returncode)
     else:
         sys.exit(1)


### PR DESCRIPTION
We want solc stdout and stderr to go to the corresponding streams, so just leave them connected when invoking the underlying solc binary.