### PR TITLE
`install artifacts` return False if requested solc versions are not available

### DIFF
--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -72,6 +72,12 @@ def installed_versions() -> [str]:
 def install_artifacts(versions: [str]) -> bool:
     releases = get_available_versions()
 
+    if "all" not in versions:
+        not_available_versions = list(set(versions).difference([*releases]))
+        if not_available_versions:
+            print(f"{', '.join(not_available_versions)} solc versions are not available.")
+            return False
+
     for version, artifact in releases.items():
         if "all" not in versions:
             if versions and version not in versions:


### PR DESCRIPTION
As suggested in https://github.com/crytic/solc-select/issues/143 , I've added validation whether all requested `solc` versions are available. 
In case if not, return `False`.

Also, I've added an informational message.