### PR TITLE
Logs message instead of error if no versions exist for `solc-select versions`

### DIFF
--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -61,14 +61,19 @@ def solc_select() -> None:
         switch_global_version(args.get(USE_VERSION), args.get("always_install"))
 
     elif args.get(SHOW_VERSIONS) is not None:
-        res = current_version()
-        if res:
-            (current_ver, source) = res
-        for version in reversed(sorted(installed_versions())):
-            if res and version == current_ver:
-                print(f"{version} (current, set by {source})")
-            else:
-                print(version)
+        if installed_versions():
+            res = current_version()
+            if res:
+                (current_ver, source) = res
+            for version in reversed(sorted(installed_versions())):
+                if res and version == current_ver:
+                    print(f"{version} (current, set by {source})")
+                else:
+                    print(version)
+        else:
+            print(
+                "No solc version installed. Run `solc-select install --help` for more information"
+            )
     elif args.get(UPGRADE) is not None:
         upgrade_architecture()
     else:

--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -61,11 +61,12 @@ def solc_select() -> None:
         switch_global_version(args.get(USE_VERSION), args.get("always_install"))
 
     elif args.get(SHOW_VERSIONS) is not None:
-        if installed_versions():
+        versions_installed = installed_versions()
+        if versions_installed:
             res = current_version()
             if res:
                 (current_ver, source) = res
-            for version in reversed(sorted(installed_versions())):
+            for version in reversed(sorted(versions_installed)):
                 if res and version == current_ver:
                     print(f"{version} (current, set by {source})")
                 else:


### PR DESCRIPTION
This PR fixes issue #152 
During the execution of `solc-select versions` a conditional statement has now been added to preview if any solc-select versions have been installed prior before proceeding, if the check fails, the code block responsible for looking up and printing installed versions is skipped and an informational message is logged.