### PR TITLE
added - solc-select install latest - feature

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -26,7 +26,7 @@ jobs:
           python -m venv /tmp/pip-audit-env
           source /tmp/pip-audit-env/bin/activate
 
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           python -m pip install .
 
 

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel twine --upgrade
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine --upgrade
+        pip install setuptools==65.5.1 wheel twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools==65.5.1 wheel twine
+        pip install setuptools wheel twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Installing '0.8.1'...
 Version '0.8.1' installed.
 ```
 
+You can also install the latest version with `solc-select install latest`
+and use the latest version with `solc-select use latest`
+
 Display the currently installed versions:
 ```
 $ solc-select versions

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     description="Manage multiple Solidity compiler versions.",
     url="https://github.com/crytic/solc-select",
     author="Trail of Bits",
-    version="1.0.2",
+    version="1.0.3",
     packages=find_packages(),
     python_requires=">=3.6",
     license="AGPL-3.0",

--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -31,7 +31,7 @@ def solc_select() -> None:
     )
     parser_install.add_argument(
         INSTALL_VERSIONS,
-        help='specific versions you want to install "0.4.25" or "all"',
+        help='specific versions you want to install "0.4.25", "all" or "latest"',
         nargs="*",
         default=[],
         type=valid_install_arg,

--- a/solc_select/constants.py
+++ b/solc_select/constants.py
@@ -20,3 +20,9 @@ MACOSX_AMD64 = "macosx-amd64"
 WINDOWS_AMD64 = "windows-amd64"
 
 EARLIEST_RELEASE = {"macosx-amd64": "0.3.6", "linux-amd64": "0.4.0", "windows-amd64": "0.4.5"}
+
+# URL
+CRYTIC_SOLC_ARTIFACTS = "https://raw.githubusercontent.com/crytic/solc/master/linux/amd64/"
+CRYTIC_SOLC_JSON = (
+    "https://raw.githubusercontent.com/crytic/solc/new-list-json/linux/amd64/list.json"
+)

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -174,6 +174,9 @@ def switch_global_version(version: str, always_install: bool) -> None:
 
 
 def valid_version(version: str) -> str:
+    latest_release = get_latest_release()
+    if version == "latest":
+        return latest_release
     match = re.search(r"^(\d+)\.(\d+)\.(\d+)$", version)
 
     if match is None:
@@ -185,8 +188,6 @@ def valid_version(version: str) -> str:
         )
 
     # pylint: disable=consider-using-with
-    latest_release = get_latest_release()
-    # pylint: disable=consider-using-with
     if Version(version) > Version(latest_release):
         raise argparse.ArgumentTypeError(
             f"Invalid version '{latest_release}' is the latest available version"
@@ -196,7 +197,7 @@ def valid_version(version: str) -> str:
 
 
 def valid_install_arg(arg: str) -> str:
-    if arg in ("all", "latest"):
+    if arg == "all":
         return arg
     return valid_version(arg)
 

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -17,6 +17,8 @@ from .constants import (
     EARLIEST_RELEASE,
     SOLC_SELECT_DIR,
     ARTIFACTS_DIR,
+    CRYTIC_SOLC_ARTIFACTS,
+    CRYTIC_SOLC_JSON,
 )
 
 Path.mkdir(ARTIFACTS_DIR, parents=True, exist_ok=True)
@@ -79,6 +81,11 @@ def install_artifacts(versions: [str]) -> bool:
                 continue
 
         (url, _) = get_url(version, artifact)
+
+        if is_linux_0818(version):
+            url = CRYTIC_SOLC_ARTIFACTS + artifact
+            print(url)
+
         artifact_file_dir = ARTIFACTS_DIR.joinpath(f"solc-{version}")
         Path.mkdir(artifact_file_dir, parents=True, exist_ok=True)
         print(f"Installing '{version}'...")
@@ -102,6 +109,10 @@ def install_artifacts(versions: [str]) -> bool:
 
 def is_older_linux(version: str) -> bool:
     return soliditylang_platform() == LINUX_AMD64 and Version(version) <= Version("0.4.10")
+
+
+def is_linux_0818(version: str) -> bool:
+    return soliditylang_platform() == LINUX_AMD64 and Version(version) == Version("0.8.18")
 
 
 def is_older_windows(version: str) -> bool:
@@ -149,8 +160,8 @@ def get_url(version: str = "", artifact: str = "") -> (str, str):
     if soliditylang_platform() == LINUX_AMD64:
         if version != "" and is_older_linux(version):
             return (
-                f"https://raw.githubusercontent.com/crytic/solc/master/linux/amd64/{artifact}",
-                "https://raw.githubusercontent.com/crytic/solc/new-list-json/linux/amd64/list.json",
+                CRYTIC_SOLC_ARTIFACTS + artifact,
+                CRYTIC_SOLC_JSON,
             )
     return (
         f"https://binaries.soliditylang.org/{soliditylang_platform()}/{artifact}",

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -71,6 +71,7 @@ def installed_versions() -> [str]:
 
 def install_artifacts(versions: [str]) -> bool:
     releases = get_available_versions()
+    versions = [get_latest_release() if ver == "latest" else ver for ver in versions]
 
     for version, artifact in releases.items():
         if "all" not in versions:
@@ -184,9 +185,7 @@ def valid_version(version: str) -> str:
         )
 
     # pylint: disable=consider-using-with
-    (_, list_url) = get_url()
-    list_json = urllib.request.urlopen(list_url).read()
-    latest_release = json.loads(list_json)["latestRelease"]
+    latest_release = get_latest_release()
     # pylint: disable=consider-using-with
     if Version(version) > Version(latest_release):
         raise argparse.ArgumentTypeError(
@@ -197,7 +196,7 @@ def valid_version(version: str) -> str:
 
 
 def valid_install_arg(arg: str) -> str:
-    if arg == "all":
+    if arg in ("all", "latest"):
         return arg
     return valid_version(arg)
 
@@ -233,3 +232,10 @@ def soliditylang_platform() -> str:
     else:
         raise argparse.ArgumentTypeError("Unsupported platform")
     return platform
+
+
+def get_latest_release() -> str:
+    (_, list_url) = get_url()
+    list_json = urllib.request.urlopen(list_url).read()
+    latest_release = json.loads(list_json)["latestRelease"]
+    return latest_release

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -46,22 +46,25 @@ def upgrade_architecture() -> None:
 
 
 def current_version() -> (str, str):
-    version = os.environ.get("SOLC_VERSION")
     source = "SOLC_VERSION"
-    if version:
-        if version not in installed_versions():
-            raise argparse.ArgumentTypeError(
-                f"Version '{version}' not installed (set by {source}). Run `solc-select install {version}`."
-            )
-    else:
-        source = SOLC_SELECT_DIR.joinpath("global-version")
-        if Path.is_file(source):
-            with open(source, encoding="utf-8") as f:
+    version = os.environ.get(source)
+    if not version:
+        source_path = SOLC_SELECT_DIR.joinpath("global-version")
+        source = source_path.as_posix()
+        if Path.is_file(source_path):
+            with open(source_path, encoding="utf-8") as f:
                 version = f.read()
         else:
             raise argparse.ArgumentTypeError(
                 "No solc version set. Run `solc-select use VERSION` or set SOLC_VERSION environment variable."
             )
+    versions = installed_versions()
+    if version not in versions:
+        raise argparse.ArgumentTypeError(
+            f"\nVersion '{version}' not installed (set by {source})."
+            f"\nRun `solc-select install {version}`."
+            f"\nOr use one of the following versions: {versions}"
+        )
     return version, source
 
 


### PR DESCRIPTION
This PR resolves issue #138 
Adds a new commandline argument feature `solc-select install latest`
Also updated the usage section of the readme.md file to include documentation for this feature and added updated the argparse helper text to include the `latest` flag