### PR TITLE
Logs error message on invalid install version

### DIFF
--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -71,7 +71,9 @@ def installed_versions() -> [str]:
 
 def install_artifacts(versions: [str]) -> bool:
     releases = get_available_versions()
-
+    for version in versions:
+        if version not in releases:
+            print(f"Unknown version '{version}'")
     for version, artifact in releases.items():
         if "all" not in versions:
             if versions and version not in versions:


### PR DESCRIPTION
This PR fixes issue #153 
Logs an informational message if any of the install versions are invalid
The command `solc-select install 0.7.99 0.7.8 0.8.0` will still install 0.7 and 0.8 while it logs an error message for `0.7.99`