### PR TITLE
Bump minimum Python version to 3.8

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -16,12 +16,14 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10"            
-        type: ["solc_upgrade", "linux","solc"]
-    steps:    
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+        type: ["solc_upgrade", "linux", "solc"]
+    steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -16,10 +16,12 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10"      
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
         type: ["solc_upgrade", "macos", "solc"]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -16,12 +16,14 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10"                  
-        type: ["windows","solc"]
-    steps:    
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+        type: ["windows", "solc"]
+    steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author="Trail of Bits",
     version="1.0.4",
     packages=find_packages(),
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     license="AGPL-3.0",
     # pylint: disable=consider-using-with
     long_description=open("README.md", encoding="utf8").read(),


### PR DESCRIPTION
3.8 has recently reached EOL but it is still used in LTS distributions like Ubuntu 20.04. This brings the minimum required Python version in line with the one on Slither and crytic-compile.