### PR TITLE
Allow using newer solc on macOS without Rosetta

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To automatically install and use a version, run `solc-select use <version> --alw
 
 ### Running on ARM (Mac M1/M2)
 
-`solc` requires Rosetta to be installed. See the FAQ on [how to install Rosetta](#oserror-errno-86-bad-cpu-type-in-executable).
+`solc` older than 0.8.24 requires Rosetta to be installed. See the FAQ on [how to install Rosetta](#oserror-errno-86-bad-cpu-type-in-executable).
 
 ## Usage
 
@@ -85,10 +85,12 @@ Feel free to stop by our [Slack channel](https://empirehacking.slack.com/) for h
 ### OSError: [Errno 86] Bad CPU type in executable
 
 On newer `solc-select` versions, this might show as `solc binaries for macOS are
-Intel-only. Please install Rosetta on your Mac to continue.`
+Intel-only. Please install Rosetta on your Mac to continue.` or `solc binaries
+previous to 0.8.24 for macOS are Intel-only. Please install Rosetta on your Mac
+to continue.`
 
-`solc` requires Rosetta to be installed. To see whether you have Rosetta
-installed on your Mac, run
+`solc` releases earlier than 0.8.24 require Rosetta to be installed. To see
+whether you have Rosetta installed on your Mac, run
 
 ```bash
 pgrep -q oahd && echo Rosetta is installed || echo Rosetta is NOT installed

--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -94,7 +94,7 @@ def solc() -> None:
         (version, _) = res
         path = ARTIFACTS_DIR.joinpath(f"solc-{version}", f"solc-{version}")
         halt_old_architecture(path)
-        halt_incompatible_system()
+        halt_incompatible_system(path)
         try:
             subprocess.run(
                 [str(path)] + sys.argv[1:],

--- a/solc_select/utils.py
+++ b/solc_select/utils.py
@@ -1,9 +1,20 @@
+from pathlib import Path
 import platform
 import subprocess
 import sys
 from typing import List
 
 from packaging.version import Version
+
+
+def mac_binary_is_universal(path: Path):
+    """Check if the Mac binary is Universal or not. Will throw an exception if run on non-macOS."""
+    assert sys.platform == "darwin"
+    result = subprocess.run(["/usr/bin/file", str(path)], capture_output=True, check=False)
+    is_universal = all(
+        text in result.stdout.decode() for text in ("Mach-O universal binary", "x86_64", "arm64")
+    )
+    return result.returncode == 0 and is_universal
 
 
 def mac_can_run_intel_binaries() -> bool:


### PR DESCRIPTION
`solc` universal binaries are now available, starting from 0.8.24. Allow Macs without Rosetta to run those binaries.

Closes #132 