### PR TITLE
Skip already installed versions in install_artifacts

### DIFF
--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -206,9 +206,18 @@ def install_artifacts(versions: [str], silent: bool = False) -> bool:
             print(f"{', '.join(not_available_versions)} solc versions are not available.")
             return False
 
+    already_installed = installed_versions()
     for version, artifact in releases.items():
         if "all" not in versions:
             if versions and version not in versions:
+                continue
+
+        artifact_file_dir = ARTIFACTS_DIR.joinpath(f"solc-{version}")
+
+        if version in already_installed:
+            if os.listdir(artifact_file_dir):
+                if not silent:
+                    print(f"Version '{version}' is already installed, skipping...")
                 continue
 
         (url, _) = get_url(version, artifact)
@@ -217,7 +226,6 @@ def install_artifacts(versions: [str], silent: bool = False) -> bool:
             url = CRYTIC_SOLC_ARTIFACTS + artifact
             print(url)
 
-        artifact_file_dir = ARTIFACTS_DIR.joinpath(f"solc-{version}")
         Path.mkdir(artifact_file_dir, parents=True, exist_ok=True)
         if not silent:
             print(f"Installing solc '{version}'...")

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -66,3 +66,18 @@ class TestUpgrade:  # pylint: disable=too-few-public-methods
         assert old_versions == new_versions, (
             f"Installed versions changed during upgrade.\nOld: {old_versions}\nNew: {new_versions}"
         )
+
+    def test_cache_already_installed(self, isolated_python_env):
+        venv = isolated_python_env
+        project_root = Path(__file__).parent.parent
+
+        # Install development version
+        run_in_venv(venv, f"pip install -e {project_root}", check=True)
+
+        run_in_venv(venv, "solc-select install 0.8.20", check=False)
+
+        result = run_in_venv(venv, "solc-select install 0.8.20", check=False)
+        already_installed = result.stdout.strip()
+        assert "Version '0.8.20' is already installed, skipping.." in already_installed, (
+            "No skipping already installed versions"
+        )


### PR DESCRIPTION
solc-select would blindly install versions even if they already existed, which can cause issues in certain scenarios such as rate limiting. When using 'solc-select install all', this could cause interruptions, but by skipping already installed versions, users can retry multiple times without redundant downloads.

This change improves efficiency and reduces unnecessary network requests by checking if a version directory exists and contains files before attempting installation.