### PR TITLE
Fix checksum fetching when we have prerelease

### DIFF
--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -319,7 +319,7 @@ def get_soliditylang_checksums(version: str) -> Tuple[str, Optional[str]]:
     response = session.get(list_url)
     response.raise_for_status()
     builds = response.json()["builds"]
-    matches = list(filter(lambda b: b["version"] == version, builds))
+    matches = list(filter(lambda b: b["version"] == version and "prerelease" not in b, builds))
 
     if not matches or not matches[0]["sha256"]:
         raise argparse.ArgumentTypeError(

--- a/tests/test_compiler_versions.py
+++ b/tests/test_compiler_versions.py
@@ -101,6 +101,12 @@ class TestCompilerVersions:
             f"solc080_fail_compile did not fail as expected. Output: {result.stdout}"
         )
 
+    def test_solc_0831_if_contains_prerelease(self, test_contracts_dir, isolated_solc_data):
+        """Test Solidity 0.8.31 compilation behavior."""
+        # Switch to 0.8.31
+        result = run_command("solc-select use 0.8.31 --always-install", check=False)
+        assert result.returncode == 0, f"Failed to switch to 0.8.31: {result.stdout}"
+
 
 class TestVersionSwitching:
     """Test version switching functionality."""


### PR DESCRIPTION
We will encounter an error when we try to install 0.8.31 atm:
```
❯ solc-select install 0.8.31
Installing solc '0.8.31'...
Traceback (most recent call last):
  File "/Users/jun/src/xxx/.venv/bin/solc-select", line 8, in <module>
    sys.exit(solc_select())
  File "/Users/jun/src/xxx/.venv/lib/python3.10/site-packages/solc_select/__main__.py", line 61, in solc_select
    status = install_artifacts(args.get(INSTALL_VERSIONS))
  File "/Users/jun/src/xxx/.venv/lib/python3.10/site-packages/solc_select/solc_select.py", line 126, in install_artifacts
    verify_checksum(version)
  File "/Users/jun/src/xxx/.venv/lib/python3.10/site-packages/solc_select/solc_select.py", line 172, in verify_checksum
    raise argparse.ArgumentTypeError(
argparse.ArgumentTypeError: Error: Checksum mismatch macosx-amd64 - 0.8.31
```


this is becasue `https://binaries.soliditylang.org/macosx-amd64/list.json` returns multiple results for `0.8.31`, `prerelease` are contained.

```
    {
      "path": "solc-macosx-amd64-v0.8.31-pre.1+commit.b59566f6",
      "version": "0.8.31",
      "prerelease": "pre.1",
      "build": "commit.b59566f6",
      "longVersion": "0.8.31-pre.1+commit.b59566f6",
      "keccak256": "0x4544c2e6fea0b05f4c51a89b169ae793ee93655d971e424e64651992cb53d878",
      "sha256": "0x7aa507bd5246bd31576998f6ec45b02313bdb3297722fc8c376141cd46975063",
      "urls": [
        "dweb:/ipfs/QmRAbx6MvALUpZUsdw6dizUKfUDiW3mDQb8uCigBgk6W7h"
      ]
    },
    {
      "path": "solc-macosx-amd64-v0.8.31+commit.fd3a2265",
      "version": "0.8.31",
      "build": "commit.fd3a2265",
      "longVersion": "0.8.31+commit.fd3a2265",
      "keccak256": "0xe24d2e6c51018020bd86cd51369e4087f3f59288577dd038326ebf84becf26c2",
      "sha256": "0xf5a243d6b2dd8fba307e36c5fefa2d8eb3ae74ba81036d1c17c971b5d346ade9",
      "urls": [
        "dweb:/ipfs/QmXnqLGQF6Dgpkegp59Z8DcSq7UeT9jY7ENAWUzYjPaq8H"
      ]
    }
```